### PR TITLE
fix int overflow problem in windows

### DIFF
--- a/Supervised Machine Learning Regression and Classification/week1/6.Train the model with gradient descent/lab_utils_uni.py
+++ b/Supervised Machine Learning Regression and Classification/week1/6.Train the model with gradient descent/lab_utils_uni.py
@@ -298,7 +298,7 @@ def plt_divergence(p_hist, J_hist, x_train,y_train):
     # Print w vs cost to see minimum
     fix_b = 100
     w_array = np.arange(-70000, 70000, 1000)
-    cost = np.zeros_like(w_array)
+    cost = np.zeros_like(w_array, np.int64)  # fix for windows
 
     for i in range(len(w_array)):
         tmp_w = w_array[i]
@@ -316,7 +316,7 @@ def plt_divergence(p_hist, J_hist, x_train,y_train):
     #===============
 
     tmp_b,tmp_w = np.meshgrid(np.arange(-35000, 35000, 500),np.arange(-70000, 70000, 500))
-    z=np.zeros_like(tmp_b)
+    z=np.zeros_like(tmp_b, np.int64)  # fix for windows
     for i in range(tmp_w.shape[0]):
         for j in range(tmp_w.shape[1]):
             z[i][j] = compute_cost(x_train, y_train, tmp_w[i][j], tmp_b[i][j] )


### PR DESCRIPTION
windows by default is int32, so force numpy to use int64 to avoid overflow